### PR TITLE
docs: update README for v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,163 @@
+# Changelog
+
+本文件记录 WPS365 CLI 各版本的主要变更。格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
+
+## [v0.2.0] - 2026-06-26
+
+### ⚠️ 不兼容变更
+
+#### 1. 命令重命名（复数 → 单数）
+
+所有资源名统一为单数形式，使用旧名称的脚本需更新：
+
+| v0.1.0（旧） | v0.2.0（新） |
+|--------------|-------------|
+| `calendar events *` | `calendar event *` |
+| `calendar event-attendees *` | `calendar event-attendee *` |
+| `calendar event-instances *` | `calendar event-instance *` |
+| `calendar event-rooms *` | `calendar event-room *` |
+| `im messages *` | `im message *` |
+| `im chats *` | `im chat *` |
+| `im chat-members *` | `im chat-member *` |
+| `im chat-messages *` | `im chat-message *` |
+| `mail mailboxes *` | `mail mailbox *` |
+| `mail mailbox-folders *` | `mail mailbox-folder *` |
+| `mail mailbox-subfolders *` | `mail mailbox-subfolder *` |
+| `mail messages *` | `mail message *` |
+| `mail drafts *` | `mail draft *` |
+| `drive files *` | `drive file *` |
+| `drive file-versions *` | `drive file-version *` |
+| `drive file-link *` | `drive link *` |
+| `dbsheet sheets *` | `dbsheet sheet *` |
+| `dbsheet fields *` | `dbsheet field *` |
+| `dbsheet records *` | `dbsheet record *` |
+| `dbsheet record-pages *` | `dbsheet record-page *` |
+| `dbsheet views *` | `dbsheet view *` |
+| `meeting participants *` | `meeting participant *` |
+| `meeting minutes *` | `meeting minute *` |
+| `meeting recordings *` | `meeting recording *` |
+
+#### 2. 移除的精装命令（改用 `api get|post`）
+
+以下命令不再提供精装入口，可通过 `api` 直接调用对应端点：
+
+**日历**
+
+| 移除的命令 | 替代方式 |
+|-----------|---------|
+| `calendar timeoff-events create` | `api post "/v7/calendars/primary/timeoff_events/create"` |
+| `calendar timeoff-events delete` | `api post "/v7/calendars/primary/timeoff_events/{id}/delete"` |
+| `calendar events batch-create` | `api post "/v7/calendars/{calendar_id}/events/batch_create"` |
+
+**即时通讯**
+
+| 移除的命令 | 替代方式 |
+|-----------|---------|
+| `im chat-bookmark add` | `api post "/v7/chats/{chat_id}/bookmarks/batch_create"` |
+| `im chat-bookmark remove` | `api post "/v7/chats/{chat_id}/bookmarks/batch_delete"` |
+| `im in-chat-member check` | `api get "/v7/chats/{chat_id}/members/is_in_chat"` |
+| `im link-chat share` | `api post "/v7/chats/{chat_id}/share_link"` |
+
+> `im chat-bookmark list` 保留。
+
+**通讯录**
+
+| 移除的命令 | 替代方式 |
+|-----------|---------|
+| `user by-email get` | 合并至 `user get --type email`，或 `api post "/v7/users/by_emails"` |
+| `user by-phone get` | 合并至 `user get --type phone`，或 `api post "/v7/users/by_phones"` |
+| `user by-ex-id get` | 合并至 `user get --type external-id`，或 `api post "/v7/users/by_ex_user_ids"` |
+
+**邮箱**
+
+| 移除的命令 | 替代方式 |
+|-----------|---------|
+| `mail contact list` | `api get "/v7/mail_contacts"` |
+| `mail contact create` | `api post "/v7/mail_contacts"` |
+| `mail contact delete` | `api post "/v7/mail_contacts/{id}/delete"` |
+
+**云文档**
+
+| 移除的命令 | 替代方式 |
+|-----------|---------|
+| `drive files batch-delete` | `api post "/v7/drives/{drive_id}/files/batch_delete"` |
+| `drive files batch-get` | `api post "/v7/drives/{drive_id}/files/batch_get"` |
+| `drive file-owner update` | `api post "/v7/drives/{drive_id}/files/{file_id}/transfer_owner"` |
+| `drive file-permission list` | `api get "/v7/drives/{drive_id}/files/{file_id}/permissions"` |
+| `drive file-permission batch-create` | `api post "/v7/drives/{drive_id}/files/{file_id}/permissions/batch_create"` |
+| `drive file-permission batch-delete` | `api post "/v7/drives/{drive_id}/files/{file_id}/permissions/batch_delete"` |
+| `drive roles list` | `api get "/v7/drives/{drive_id}/roles"` |
+
+**多维表**
+
+| 移除的命令 | 替代方式 |
+|-----------|---------|
+| `dbsheet views delete` | `api post "/v7/coop/dbsheet/{file_id}/views/{view_id}/delete"` |
+| `dbsheet views get` | `api get "/v7/coop/dbsheet/{file_id}/views/{view_id}"` |
+| `dbsheet views list` | `api get "/v7/coop/dbsheet/{file_id}/views"` |
+| `dbsheet views update` | `api post "/v7/coop/dbsheet/{file_id}/views/{view_id}/update"` |
+| `dbsheet hooks create` | `api post "/v7/coop/dbsheet/{file_id}/hooks/create"` |
+| `dbsheet hooks list` | `api get "/v7/coop/dbsheet/{file_id}/hooks"` |
+| `dbsheet hooks delete` | `api post "/v7/coop/dbsheet/{file_id}/hooks/{hook_id}/delete"` |
+
+> `dbsheet view create` 保留。
+
+**会议**
+
+| 移除的命令 | 替代方式 |
+|-----------|---------|
+| `meeting recordings start` | `api post "/v7/meetings/{meeting_id}/recordings/start"` |
+| `meeting recordings stop` | `api post "/v7/meetings/{meeting_id}/recordings/stop"` |
+| `meeting rooms list` | `api get "/v7/meeting_rooms"` |
+| `meeting rooms get` | `api get "/v7/meeting_rooms/{room_id}"` |
+| `meeting rooms create` | `api post "/v7/meeting_rooms/create"` |
+| `meeting rooms update` | `api post "/v7/meeting_rooms/{room_id}/update"` |
+| `meeting rooms delete` | `api post "/v7/meeting_rooms/{room_id}/delete"` |
+| `meeting rooms batch-get` | `api post "/v7/meeting_rooms/batch_get"` |
+| `meeting rooms search` | `api post "/v7/meeting_rooms/search"` |
+| `meeting room-bookings batch-get` | `api post "/v7/meeting_room_bookings/batch_get"` |
+| `meeting room-bookings-status update` | `api post "/v7/meeting_room_bookings/{booking_id}/update_status"` |
+| `meeting room-levels list` | `api get "/v7/meeting_room_levels"` |
+| `meeting room-levels get` | `api get "/v7/meeting_room_levels/{room_level_id}"` |
+| `meeting room-levels create` | `api post "/v7/meeting_room_levels/create"` |
+| `meeting room-levels update` | `api post "/v7/meeting_room_levels/{room_level_id}/update"` |
+| `meeting room-levels delete` | `api post "/v7/meeting_room_levels/{room_level_id}/delete"` |
+| `meeting room-levels batch-get` | `api post "/v7/meeting_room_levels/batch_get"` |
+| `meeting room-settings batch-get` | `api post "/v7/meeting_room_settings/batch_get"` |
+| `meeting room-settings update` | `api post "/v7/meeting_room_settings/{room_id}/update"` |
+
+#### 3. 认证命令变更
+
+| v0.1.0（旧） | v0.2.0（新） | 说明 |
+|--------------|-------------|------|
+| `auth login --app` | 设置 `WPS365_CLIENT_ID` + `WPS365_CLIENT_SECRET` 环境变量 | 应用身份不再需要显式 login，CLI 自动获取 token |
+| `auth refresh` | 已移除 | token 刷新完全自动化，无需手动操作 |
+
+### 新增
+
+- `--jq` 内置过滤器：无需安装 jq，直接在命令行过滤 JSON 输出
+- `--flatten` 扁平化：嵌套对象展开为平坦结构，适合 table/tsv/csv 列式输出
+- `--no-color` 禁色模式：适合日志采集和 CI/CD 管道
+- `ndjson` / `csv` 输出格式：支持流式处理和电子表格导入
+- `provider` 子命令：统一管理 provider 配置（add / list / show / update / remove）
+
+### 改进
+
+- Provider 统一运行时：收敛所有命令到统一的 provider 模型，简化扩展与维护
+- Token 并发安全：文件锁序列化 token 刷新，避免多进程竞争
+- Spec 生命周期管理：支持 spec 文件自动下载与按需更新
+
+## [v0.1.0] - 2026-05-20
+
+### 新增
+
+- 首次发布，覆盖日历、即时通讯、通讯录、邮箱、云文档、多维表、会议 7 大业务域
+- `api get|post` 通用命令兜底全量 OpenAPI 端点
+- OAuth 2.0 认证（用户授权 + 应用身份）
+- 多格式输出：json / yaml / table / tsv
+- Dry Run 模式
+- 跨平台安装脚本（bash / PowerShell）
+- 安全凭证存储（Keychain / AES-256-GCM 加密文件）
+
+[v0.2.0]: https://github.com/wps365-open/cli/releases/tag/v0.2.0
+[v0.1.0]: https://github.com/wps365-open/cli/releases/tag/v0.1.0

--- a/README.en.md
+++ b/README.en.md
@@ -11,15 +11,19 @@ The official WPS 365 CLI tool — a command-line gateway for developers and AI A
 
 ## Features
 
-| Category | Capabilities |
-|----------|-------------|
-| 📅 Calendar | List calendars, create/update/delete events, manage attendees & rooms, free/busy queries, time-off events, batch operations |
-| 💬 Messenger | Send/reply/recall messages, chat CRUD, member management, message lists, urgent messages, bookmarks |
-| 👤 Contacts | Current user, user list, search by name/email/phone, batch queries, department & offboarding management |
-| 📧 Mail | Mailbox management, folder browsing, message list/detail/search, send & drafts, mail groups & contacts |
-| 📁 Drive | Drive management, file list/upload/download/search, batch operations, permissions, versions, share links |
-| 📋 DbSheet | Table/field/view management, record CRUD & search, dashboards, webhooks, attachments |
-| 🎥 Meetings | Online meeting management, participant management, reservations, minutes & recordings, room & level management |
+The current release (v0.2.0) provides **101 curated commands** across 7 business domains:
+
+| Category | Commands | Capabilities |
+|----------|:--------:|-------------|
+| 📅 Calendar | 25 | Calendar CRUD & subscription, event CRUD & search, attendees, rooms, free/busy, minutes |
+| 💬 Messenger | 15 | Send/reply/recall messages, chat CRUD, member management, message history, P2P chat, unread count |
+| 👤 Contacts | 5 | Current user, user list & search, department list |
+| 📧 Mail | 8 | Mailbox management, folder browsing, message list/detail/search, drafts |
+| 📁 Drive | 21 | Drive management, file CRUD & search, batch copy/move, versions, share links |
+| 📋 DbSheet | 14 | Table/field management, record CRUD & search |
+| 🎥 Meetings | 13 | Meeting management, participants, minutes & recordings |
+
+> Uncovered endpoints are accessible via `api get|post` for full API coverage.
 
 ## Installation & Quick Start
 
@@ -90,16 +94,16 @@ Semantic parameters, smart defaults, automatic auth constraint validation — fr
 
 ```bash
 wps365-cli user me
-wps365-cli calendar events create primary \
+wps365-cli calendar event create primary \
   --name "Weekly Sync" --from "2024-01-15T14:00:00+08:00" --to "2024-01-15T15:00:00+08:00"
-wps365-cli im messages send --to u1 --to u2 --text "hello"
+wps365-cli im message send --to u1 --to u2 --text "hello"
 ```
 
 Run `wps365-cli <resource> --help` to see all subcommands.
 
 ### 2. Raw API Calls
 
-Call any WPS 365 Open Platform endpoint directly, covering all APIs.
+Uncovered endpoints are accessible via `api get|post` to call any WPS 365 Open Platform endpoint directly:
 
 ```bash
 wps365-cli api get "/v7/users/current"
@@ -109,19 +113,21 @@ wps365-cli api post "/v7/calendars/create" \
 
 ## Authentication
 
-| Command | Description |
-|---------|-------------|
-| `auth setup` | Configure OAuth client credentials (interactive, supports CLI flags and env vars) |
-| `auth login` | Log in with `--scopes` for user identity, or `--app` for application identity |
-| `auth token` | View current token info |
-| `auth status` | View authentication status |
+| Command | Description | Use Case |
+|---------|-------------|----------|
+| `auth setup` | Configure OAuth client credentials | First-time setup, interactive guided |
+| `auth login` | Log in with `--scopes` | Browser-based OAuth user authorization |
+| `auth status` | View authentication status | Check token validity and expiry |
+| `auth token` | Output current access token | Pass to external tools: `curl -H "Authorization: Bearer $(wps365-cli auth token)"` |
+| `auth logout` | Remove local tokens | Sign out; credentials retained for re-login |
+| `auth clean` | Clear all auth data | Full reset; requires `auth setup` again |
 
 ### Auth Modes
 
 | Mode | Description | Acquisition |
 |------|-------------|-------------|
 | `delegated` | User authorization, for user-scoped endpoints (current user, personal tasks, etc.) | `auth login --scopes "..."` |
-| `app` | Application identity, for server-to-server or app-only endpoints | `auth login --app` |
+| `app` | Application identity, for server-to-server or app-only endpoints | Set `WPS365_CLIENT_ID` + `WPS365_CLIENT_SECRET` env vars; CLI auto-acquires token |
 
 Commands automatically select the compatible auth mode based on OpenAPI `security`. Use `--token-type` to override explicitly. Incompatible overrides produce an error rather than silently switching.
 
@@ -129,13 +135,10 @@ Commands automatically select the compatible auth mode based on OpenAPI `securit
 # Delegated login (browser-based OAuth)
 wps365-cli auth login --scopes "kso.user_base.read,kso.calendar.read"
 
-# App login (client credentials grant)
-wps365-cli auth login --app
-
-# Non-interactive (CI/CD)
+# App identity (CI/CD — no login needed, uses env vars)
 export WPS365_CLIENT_ID="<client-id>"
 export WPS365_CLIENT_SECRET="<client-secret>"
-wps365-cli auth login --app
+wps365-cli user list   # auto-acquires app token via client_credentials
 ```
 
 ## Advanced Usage
@@ -147,11 +150,27 @@ wps365-cli auth login --app
 -o yaml      # YAML
 -o table     # Human-readable table
 -o tsv       # Tab-separated (for piping)
+-o ndjson    # Newline-delimited JSON (for streaming)
+-o csv       # CSV format
 ```
 
 ```bash
 wps365-cli -o yaml user me
 wps365-cli -o table calendar list
+wps365-cli -o csv dbsheet record list --file-id <id> --sheet-id <id>
+```
+
+### Output Pipeline
+
+```bash
+# Built-in jq filter (no external jq required)
+wps365-cli user me --jq '.name'
+
+# Flatten nested objects for columnar outputs
+wps365-cli -o table drive file list --flatten
+
+# Disable colorized output (for logs or CI)
+wps365-cli --no-color user list
 ```
 
 ### Dry Run
@@ -161,7 +180,7 @@ Preview requests without sending, useful for debugging and script validation:
 ```bash
 wps365-cli --dry-run user me
 wps365-cli --dry-run api get "/v7/users/current"
-wps365-cli --dry-run -o json im messages send --to u1 --text "hello"
+wps365-cli --dry-run -o json im message send --to u1 --text "hello"
 ```
 
 
@@ -187,8 +206,8 @@ wps365-cli --dry-run -o json im messages send --to u1 --text "hello"
 
 `client_secret` and tokens are stored in a secure backend — plaintext never touches disk:
 
-- **Keychain** (default on macOS): uses system Keychain
-- **Encrypted file**: provide a key via `WPS365_KEYRING_PASSWORD`, encrypted with AES-256-GCM
+- **Keychain** (macOS/Windows default): uses system Keychain / Credential Manager
+- **Encrypted file** (Linux default): AES-256-GCM encrypted. Auto-generates a random key when `WPS365_KEYRING_PASSWORD` is not set
 
 Token lifecycle is fully automatic:
 
@@ -196,16 +215,6 @@ Token lifecycle is fully automatic:
 - 401 responses trigger transparent refresh and retry
 - Delegated tokens are refreshed via refresh_token; if the refresh token itself expires, the CLI prompts to `auth login` again
 - App tokens are re-acquired via client_credentials when expired
-
-
-### Related Documentation
-
-- [ARCHITECTURE.md](ARCHITECTURE.md) — Project architecture and directory responsibilities
-- [docs/design-docs/auth.md](docs/design-docs/auth.md) — Authentication and credential design
-- [docs/design-docs/spec-discovery.md](docs/design-docs/spec-discovery.md) — Spec file management and loading order
-- [docs/design-docs/curated-commands.md](docs/design-docs/curated-commands.md) — Curated command design principles
-- [docs/design-docs/openapi-cli-mapping.md](docs/design-docs/openapi-cli-mapping.md) — Command-to-API mapping rules
-- [docs/design-docs/testing.md](docs/design-docs/testing.md) — Testing strategy and E2E constraints
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@
 
 WPS 365 官方 CLI 工具 — 面向开发者与 AI Agent 的命令行入口。覆盖日历、协作、通讯录、邮箱、云文档、多维表、会议等 7 大业务域，未覆盖的接口通过 `api get|post` 直接访问。
 
-[安装](#安装与快速开始) · [命令体系](#双轨命令体系) · [认证](#认证) · [进阶用法](#进阶用法) · [安全](#凭证与安全) · [开发](#开发) · [贡献](#贡献)
+[安装](#安装与快速开始) · [命令](#双轨命令体系) · [认证](#认证) · [进阶用法](#进阶用法) · [安全](#凭证与安全) · [贡献](#贡献)
 
 ## 功能
 
 | 类别 | 能力 |
 |------|------|
-| 📅 日历 | 查询日历列表、创建/更新/删除日程、管理参会人与会议室、忙闲查询、请假日程、批量操作 |
-| 💬 即时通讯 | 发送/回复/撤回消息、群聊增删改查、成员管理、消息列表、加急、书签 |
-| 👤 通讯录 | 查询当前用户、用户列表、按姓名/邮箱/手机号搜索、批量查询、部门与离职人员管理 |
-| 📧 邮箱 | 邮箱管理、文件夹浏览、邮件列表/详情/搜索、发送与草稿、邮件组与通讯录管理 |
-| 📁 云文档 | 驱动器管理、文件列表/上传/下载/搜索、批量操作、权限管理、版本管理、分享链接 |
-| 📋 多维表 | 数据表/字段/视图管理、记录增删改查与搜索、仪表盘、Webhook、附件 |
-| 🎥 会议 | 在线会议管理、参会人管理、预约会议、会议纪要与录制、会议室与层级管理 |
+| 📅 日历 | 日历增删改查与订阅、日程增删改查/搜索、参与者管理、会议室管理、忙闲查询、会议纪要、重复日程实例 |
+| 💬 即时通讯 | 发送/回复/撤回消息、群聊增删改查、成员管理、消息列表、P2P 会话、未读数 |
+| 👤 通讯录 | 查询当前用户、用户列表与搜索、部门列表 |
+| 📧 邮箱 | 邮箱管理、文件夹浏览、邮件列表/详情/搜索、发送与草稿 |
+| 📁 云文档 | 驱动器管理、文件增删改查/搜索、批量复制/移动、版本管理、分享链接 |
+| 📋 多维表 | 数据表/字段管理、记录增删改查与搜索 |
+| 🎥 会议 | 在线会议管理、参会人管理、会议纪要与录制 |
 
 ## 安装与快速开始
 
@@ -90,16 +90,16 @@ CLI 提供两种粒度的调用方式，精装命令覆盖高频场景，`api` �
 
 ```bash
 wps365-cli user me
-wps365-cli calendar events create primary \
+wps365-cli calendar event create primary \
   --name "周会" --from "2024-01-15T14:00:00+08:00" --to "2024-01-15T15:00:00+08:00"
-wps365-cli im messages send --to u1 --to u2 --text "hello"
+wps365-cli im message send --to u1 --to u2 --text "hello"
 ```
 
 运行 `wps365-cli <resource> --help` 查看所有子命令。
 
 ### 2. 通用 API 调用
 
-直接调用任意 WPS 365 开放平台端点，覆盖全部 API。
+未覆盖的接口通过 `api get|post` 直接调用任意 WPS 365 开放平台端点：
 
 ```bash
 wps365-cli api get "/v7/users/current"
@@ -114,12 +114,11 @@ wps365-cli api post "/v7/calendars/create" \
 | 命令 | 说明 | 使用场景 |
 |------|------|----------|
 | `auth setup` | 配置 OAuth 客户端凭证 | 首次使用，交互式引导保存 `client_id` 和 `client_secret` |
-| `auth login` | 登录授权 | `--scopes` 指定权限进行用户授权；`--app` 切换为应用身份 |
+| `auth login` | 登录授权 | `--scopes` 指定权限进行用户授权（浏览器 OAuth） |
 | `auth status` | 查看认证状态 | 检查当前 token 是否有效、过期时间、认证模式等 |
 | `auth token` | 输出当前 access token | 将 token 传递给其他工具或脚本，如 `curl -H "Authorization: Bearer $(wps365-cli auth token)"` |
-| `auth refresh` | 手动刷新 token | 主动刷新即将过期的 token，需指定 `--delegated` 或 `--app` |
-| `auth logout` | 删除本地 token | 退出登录，支持 `--app` / `--delegated` 选择性删除；凭证保留，可直接重新 `login` |
-| `auth clean` | 清理所有认证数据 | 凭证损坏、密钥不匹配或需要完全重置时使用；清除后需从 `setup` 重新开始。`--force` 跳过确认 |
+| `auth logout` | 删除本地 token | 退出登录；凭证保留，可直接重新 `login` |
+| `auth clean` | 清理所有认证数据 | 凭证损坏或需要完全重置时使用；清除后需从 `setup` 重新开始 |
 
 ```bash
 # 1. 首次配置（交互式引导）
@@ -128,24 +127,21 @@ wps365-cli auth setup
 # 2. 用户身份登录（浏览器 OAuth 授权）
 wps365-cli auth login --scopes "kso.user_base.read,kso.calendar.read"
 
-# 3. 应用身份登录（client credentials 授权）
-wps365-cli auth login --app
-
-# 4. 非交互式（CI/CD 场景）
+# 3. 应用身份（CI/CD 场景，通过环境变量，无需 login）
 export WPS365_CLIENT_ID="<client-id>"
 export WPS365_CLIENT_SECRET="<client-secret>"
-wps365-cli auth login --app
+wps365-cli user list   # 自动使用 client_credentials 获取 app token
 
-# 5. 查看当前认证状态
+# 4. 查看当前认证状态
 wps365-cli auth status
 
-# 6. 将 token 传给其他工具
+# 5. 将 token 传给其他工具
 curl -H "Authorization: Bearer $(wps365-cli auth token)" https://open.wps.cn/v7/users/current
 
-# 7. 退出登录（保留凭证，下次可直接 login）
+# 6. 退出登录（保留凭证，下次可直接 login）
 wps365-cli auth logout
 
-# 8. 完全重置（清除所有 token、凭证和自动密钥）
+# 7. 完全重置（清除所有 token、凭证和自动密钥）
 wps365-cli auth clean --force
 ```
 
@@ -154,7 +150,7 @@ wps365-cli auth clean --force
 | 模式 | 说明 | 获取方式 |
 |------|------|----------|
 | `delegated` | 用户授权身份，适用于当前用户、个人待办等用户态接口 | `auth login --scopes "..."` |
-| `app` | 应用身份，适用于服务端调用或应用态接口 | `auth login --app` |
+| `app` | 应用身份，适用于服务端调用或应用态接口 | 设置 `WPS365_CLIENT_ID` + `WPS365_CLIENT_SECRET` 环境变量，CLI 自动获取 |
 
 命令根据底层 OpenAPI `security` 自动选择认证模式，`--token-type` 可显式覆盖。不兼容时直接报错，不静默切换。
 
@@ -167,11 +163,27 @@ wps365-cli auth clean --force
 -o yaml      # YAML
 -o table     # 易读表格
 -o tsv       # Tab 分隔（适合管道处理）
+-o ndjson    # 换行分隔 JSON（适合流式处理）
+-o csv       # CSV 格式
 ```
 
 ```bash
 wps365-cli -o yaml user me
 wps365-cli -o table calendar list
+wps365-cli -o csv dbsheet record list --file-id <id> --sheet-id <id>
+```
+
+### 输出管线
+
+```bash
+# 内置 jq 过滤器（无需安装 jq）
+wps365-cli user me --jq '.name'
+
+# 扁平化嵌套对象，适合 table/tsv/csv 输出
+wps365-cli -o table drive file list --flatten
+
+# 禁用彩色输出（适合日志或 CI 场景）
+wps365-cli --no-color user list
 ```
 
 ### Dry Run
@@ -181,7 +193,7 @@ wps365-cli -o table calendar list
 ```bash
 wps365-cli --dry-run user me
 wps365-cli --dry-run api get "/v7/users/current"
-wps365-cli --dry-run -o json im messages send --to u1 --text "hello"
+wps365-cli --dry-run -o json im message send --to u1 --text "hello"
 ```
 
 


### PR DESCRIPTION
- Update command counts and feature table (152 → 101 curated commands)
- Normalize command names to singular form (events→event, files→file)
- Add full command list with all 101 curated commands
- Document new flags: --jq, --flatten, --no-color
- Document new output formats: ndjson, csv
- Add v0.2.0 changelog section
- Update English README to match