### PR TITLE
docs: fix curated command examples for v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 本文件记录 WPS365 CLI 各版本的主要变更。格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [Unreleased]
+
+## [v0.3.1] - 2026-07-22
+
+### 修复
+
+- README 精装命令示例对齐当前 CLI：`calendar event create` 使用 `--start`/`--end`；`im message send` 使用逗号分隔的 `--to`
+
+### 变更
+
+- 安装示例指定版本改为 `WPS365_VERSION=v0.3.1`
+
 ## [v0.3.0] - 2026-07-22
 
 ### 新增
@@ -182,7 +194,7 @@
 - 跨平台安装脚本（bash / PowerShell）
 - 安全凭证存储（Keychain / AES-256-GCM 加密文件）
 
+[v0.3.1]: https://github.com/wps365-open/cli/releases/tag/v0.3.1
+[v0.3.0]: https://github.com/wps365-open/cli/releases/tag/v0.3.0
 [v0.2.0]: https://github.com/wps365-open/cli/releases/tag/v0.2.0
 [v0.1.0]: https://github.com/wps365-open/cli/releases/tag/v0.1.0
-
-[v0.3.0]: https://github.com/wps365-open/cli/releases/tag/v0.3.0

--- a/README.en.md
+++ b/README.en.md
@@ -51,7 +51,7 @@ Customize via environment variables:
 
 ```bash
 # Install a specific version
-curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_VERSION=v0.3.0 bash
+curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_VERSION=v0.3.1 bash
 
 # Custom install directory
 curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_INSTALL_DIR=~/.local/bin bash
@@ -59,7 +59,7 @@ curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | W
 
 ```powershell
 # PowerShell: install a specific version
-$env:WPS365_VERSION="v0.3.0"; irm https://raw.githubusercontent.com/wps365-open/cli/main/install.ps1 | iex
+$env:WPS365_VERSION="v0.3.1"; irm https://raw.githubusercontent.com/wps365-open/cli/main/install.ps1 | iex
 
 # PowerShell: custom install directory
 $env:WPS365_INSTALL_DIR="C:\tools"; irm https://raw.githubusercontent.com/wps365-open/cli/main/install.ps1 | iex
@@ -149,11 +149,11 @@ Semantic parameters, smart defaults, automatic auth constraint validation — fr
 
 ```bash
 wps365-cli user me
-wps365-cli calendar events create primary \
+wps365-cli calendar event create primary \
   --name "Weekly Sync" \
-  --from "2026-07-21T14:00:00+08:00" \
-  --to "2026-07-21T15:00:00+08:00"
-wps365-cli im messages send --to u1 --to u2 --text "hello"
+  --start "2026-07-21T14:00:00+08:00" \
+  --end "2026-07-21T15:00:00+08:00"
+wps365-cli im message send --to "u1,u2" --text "hello"
 ```
 
 Run `wps365-cli <resource> --help` to see all subcommands.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | b
 
 ```bash
 # 安装指定版本
-curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_VERSION=v0.3.0 bash
+curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_VERSION=v0.3.1 bash
 
 # 自定义安装目录
 curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_INSTALL_DIR=~/.local/bin bash
@@ -55,7 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | W
 
 ```powershell
 # PowerShell: 安装指定版本
-$env:WPS365_VERSION="v0.3.0"; irm https://raw.githubusercontent.com/wps365-open/cli/main/install.ps1 | iex
+$env:WPS365_VERSION="v0.3.1"; irm https://raw.githubusercontent.com/wps365-open/cli/main/install.ps1 | iex
 
 # PowerShell: 自定义安装目录
 $env:WPS365_INSTALL_DIR="C:\tools"; irm https://raw.githubusercontent.com/wps365-open/cli/main/install.ps1 | iex
@@ -145,11 +145,11 @@ CLI 提供两种粒度的调用方式，精装命令覆盖高频场景，`api` �
 
 ```bash
 wps365-cli user me
-wps365-cli calendar events create primary \
+wps365-cli calendar event create primary \
   --name "周会" \
-  --from "2026-07-21T14:00:00+08:00" \
-  --to "2026-07-21T15:00:00+08:00"
-wps365-cli im messages send --to u1 --to u2 --text "hello"
+  --start "2026-07-21T14:00:00+08:00" \
+  --end "2026-07-21T15:00:00+08:00"
+wps365-cli im message send --to "u1,u2" --text "hello"
 ```
 
 运行 `wps365-cli <resource> --help` 查看所有子命令。


### PR DESCRIPTION
## Summary
- Fix outdated curated examples in README (zh/en): `calendar event create` with `--start`/`--end`, `im message send` with CSV `--to`
- Record v0.3.1 changelog entry and bump install example `WPS365_VERSION` to `v0.3.1`

## Test plan
- [x] Spot-check README curated examples against `wps365-cli calendar event create --help` and `wps365-cli im message send --help`
- [x] Confirm install snippets reference `v0.3.1`


Made with [Cursor](https://cursor.com)