### PR TITLE
docs: default macOS/Linux install path to ~/.local/bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### 变更
+
+- macOS / Linux 默认安装目录从 `/usr/local/bin` 改为 `~/.local/bin`，无需 sudo
+
 ## [v0.3.2] - 2026-08-13
 
 ### 新增

--- a/README.en.md
+++ b/README.en.md
@@ -49,14 +49,14 @@ irm https://raw.githubusercontent.com/wps365-open/cli/main/install.ps1 | iex
 curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | bash
 ```
 
-Customize via environment variables:
+macOS / Linux install to `~/.local/bin` by default (no sudo). Customize via environment variables:
 
 ```bash
 # Install a specific version
 curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_VERSION=v0.3.2 bash
 
 # Custom install directory
-curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_INSTALL_DIR=~/.local/bin bash
+curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_INSTALL_DIR=/usr/local/bin bash
 ```
 
 ```powershell

--- a/README.en.md
+++ b/README.en.md
@@ -56,7 +56,7 @@ macOS / Linux install to `~/.local/bin` by default (no sudo). Customize via envi
 curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_VERSION=v0.3.2 bash
 
 # Custom install directory
-curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_INSTALL_DIR=/usr/local/bin bash
+curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_INSTALL_DIR=~/.local/bin bash
 ```
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ irm https://raw.githubusercontent.com/wps365-open/cli/main/install.ps1 | iex
 curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | bash
 ```
 
-可通过环境变量自定义：
+macOS / Linux 默认安装到 `~/.local/bin`（无需 sudo）。可通过环境变量自定义：
 
 ```bash
 # 安装指定版本
 curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_VERSION=v0.3.2 bash
 
 # 自定义安装目录
-curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_INSTALL_DIR=~/.local/bin bash
+curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_INSTALL_DIR=/usr/local/bin bash
 ```
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ macOS / Linux 默认安装到 `~/.local/bin`（无需 sudo）。可通过环境�
 curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_VERSION=v0.3.2 bash
 
 # 自定义安装目录
-curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_INSTALL_DIR=/usr/local/bin bash
+curl -fsSL https://raw.githubusercontent.com/wps365-open/cli/main/install.sh | WPS365_INSTALL_DIR=~/.local/bin bash
 ```
 
 ```powershell

--- a/install.sh
+++ b/install.sh
@@ -5,10 +5,10 @@ REPO="wps365-open/cli"
 BINARY_NAME="wps365-cli"
 GITHUB_BASE="https://github.com/${REPO}/releases"
 
-# Windows (Git Bash / MINGW) 使用用户目录，其他系统使用 /usr/local/bin
+# Windows (Git Bash / MINGW) 使用用户目录；macOS / Linux 使用 ~/.local/bin（无需 sudo）
 case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*) _DEFAULT_DIR="$HOME/.wps365/bin" ;;
-    *)                    _DEFAULT_DIR="/usr/local/bin" ;;
+    *)                    _DEFAULT_DIR="${HOME}/.local/bin" ;;
 esac
 INSTALL_DIR="${WPS365_INSTALL_DIR:-$_DEFAULT_DIR}"
 TMPDIR_CLEANUP=""


### PR DESCRIPTION
## Summary
- macOS / Linux 默认安装目录从 `/usr/local/bin` 改为 `~/.local/bin`，无需 sudo
- 自定义安装目录示例改为 `/usr/local/bin`
