### PR TITLE
fix(install): verify_install 优先校验实际安装路径

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -135,13 +135,18 @@ download_and_install() {
 }
 
 verify_install() {
-    if command -v "$BINARY_NAME" > /dev/null 2>&1; then
-        local installed_path
+    local installed_path=""
+    if [ -x "${INSTALL_DIR}/${BINARY_NAME}" ]; then
+        installed_path="${INSTALL_DIR}/${BINARY_NAME}"
+    elif command -v "$BINARY_NAME" > /dev/null 2>&1; then
         installed_path="$(command -v "$BINARY_NAME")"
+    fi
+
+    if [ -n "$installed_path" ]; then
         ok "${BINARY_NAME} 已安装到 ${installed_path}"
 
         local ver_output
-        ver_output="$("$BINARY_NAME" --version 2>/dev/null || echo '(无法获取版本)')"
+        ver_output="$("$installed_path" --version 2>/dev/null || echo '(无法获取版本)')"
         info "版本: ${ver_output}"
     else
         warn "${BINARY_NAME} 已安装到 ${INSTALL_DIR}/${BINARY_NAME}"


### PR DESCRIPTION
## 摘要

`install.sh` 在自定义 `WPS365_INSTALL_DIR` 时，最终校验用 `command -v wps365-cli` 判断安装结果：如果 PATH 里已存在旧版本，会优先返回旧路径，导致「明明装到了自定义目录，最后却提示装到了旧路径」的误导（见 #8）。

## 变更

`verify_install()` 改为：

1. 优先校验 `${INSTALL_DIR}/${BINARY_NAME}` 是否存在且可执行 → 报告实际安装路径；
2. 否则 fallback 到 `command -v`；
3. 都没有时维持原「不在 PATH」提示。

## 验证

- 场景 A：PATH 无旧版本 + 自定义目录 → 提示显示自定义目录。
- 场景 B：PATH 有旧版本 + 自定义目录 → 提示仍显示自定义目录（修复前会显示旧路径）。

Closes #8
